### PR TITLE
Allow use of g flag in Regular Expressions: Check for All or None

### DIFF
--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-all-or-none.english.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/regular-expressions/check-for-all-or-none.english.md
@@ -32,13 +32,13 @@ Change the regex <code>favRegex</code> to match both the American English (favor
 ```yml
 tests:
   - text: Your regex should use the optional symbol, <code>?</code>.
-    testString: assert(favRegex.source.match(/\?/).length > 0);
+    testString: myRegex.lastIndex = 0; assert(favRegex.source.match(/\?/).length > 0);
   - text: Your regex should match <code>"favorite"</code>
-    testString: assert(favRegex.test("favorite"));
+    testString: myRegex.lastIndex = 0; assert(favRegex.test("favorite"));
   - text: Your regex should match <code>"favourite"</code>
-    testString: assert(favRegex.test("favourite"));
+    testString: myRegex.lastIndex = 0; assert(favRegex.test("favourite"));
   - text: Your regex should not match <code>"fav"</code>
-    testString: assert(!favRegex.test("fav"));
+    testString: myRegex.lastIndex = 0; assert(!favRegex.test("fav"));
 
 ```
 


### PR DESCRIPTION
added functionality of tests to allow for the use of g flag by resetting the lastIndex as per example in https://github.com/freeCodeCamp/freeCodeCamp/pull/37941.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes ##38641

<!-- Feel free to add any addtional description of changes below this line -->

First time contribution, hope it helps!
